### PR TITLE
fix: migrate gateway from x402.serendb.com to api.serendb.com

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,18 +1,14 @@
-# x402 gateway base URL
-X402_GATEWAY_URL=https://x402.serendb.com
+# Seren gateway base URL
+X402_GATEWAY_URL=https://api.serendb.com
+
+# API key for Seren gateway (required, keep secret)
+SEREN_API_KEY=
 
 # Flat fee pricing (USD) - provider pricing includes margin
 FLAT_FEE_USD=0.75
 
-# Publisher IDs for council members
-CLAUDE_PUBLISHER_ID=d94e8d25-1561-46f7-88d1-9ee9a28e0e2a
-OPENAI_PUBLISHER_ID=df224e6a-def9-498a-a3c0-0db89b883753
-MOONSHOT_PUBLISHER_ID=25a50482-afaa-4772-8098-8b10533a8281
-GEMINI_PUBLISHER_ID=29630efc-e2d4-42eb-aa38-a5b235899e24
-PERPLEXITY_PUBLISHER_ID=9403e027-fd7e-4c90-8492-ef97bd4c596b
-
 # Behavior defaults
-DEFAULT_CHAIRMAN=claude-opus-4.5
+DEFAULT_CHAIRMAN=claude-opus-4-5
 MIN_RESPONSES_REQUIRED=3
 RETRY_ATTEMPTS=1
 REQUEST_TIMEOUT_SECONDS=120

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,11 +23,13 @@ User Query → FastAPI Backend → x402 Gateway → Multiple LLM Publishers
 - Storage: JSON files in `data/conversations/`
 - Payments: x402 protocol via Seren gateway
 
-**Key x402 Publishers:**
-- Anthropic Claude: `d94e8d25-1561-46f7-88d1-9ee9a28e0e2a`
-- OpenAI: `df224e6a-def9-498a-a3c0-0db89b883753`
-- Moonshot (Kimi K2): `25a50482-afaa-4772-8098-8b10533a8281`
-- Perplexity (Sonar): `9403e027-fd7e-4c90-8492-ef97bd4c596b`
+**Council Publisher Slugs:**
+
+- Anthropic Claude: `anthropic-claude-api`
+- OpenAI (GPT-5): `openai`
+- Moonshot (Kimi K2): `moonshot-ai`
+- Google Gemini: `google-gemini-3`
+- Perplexity (Sonar): `perplexity`
 
 ## Build Commands
 
@@ -67,9 +69,8 @@ pytest -k "test_name"     # Run specific test
 ## Environment Variables
 
 ```bash
-AGENT_WALLET=0x...          # Required: Your agent wallet address
-X402_GATEWAY_URL=https://x402.serendb.com
-PAYMENT_DELEGATION=true     # Auto-pay from prepaid balance
+X402_GATEWAY_URL=https://api.serendb.com  # Seren gateway base URL
+SEREN_API_KEY=...                         # Required: API key for gateway auth
 DATA_DIR=data/conversations
 ```
 

--- a/backend/config.py
+++ b/backend/config.py
@@ -12,13 +12,13 @@ class CouncilMember:
     def __init__(
         self,
         name: str,
-        publisher_id: str,
+        slug: str,
         model: str,
         endpoint_path: str = "/chat/completions",
         api_format: str = "openai",
     ):
         self.name = name
-        self.publisher_id = publisher_id
+        self.slug = slug
         self.model = model
         self.endpoint_path = endpoint_path
         self.api_format = api_format  # "openai" or "anthropic"
@@ -27,13 +27,8 @@ class CouncilMember:
 class Settings(BaseSettings):
     """Application settings loaded from environment variables."""
 
-    x402_gateway_url: str = Field(..., description="x402 gateway base URL")
-
-    claude_publisher_id: str
-    openai_publisher_id: str
-    moonshot_publisher_id: str
-    gemini_publisher_id: str
-    perplexity_publisher_id: str
+    x402_gateway_url: str = Field(..., description="Seren gateway base URL")
+    seren_api_key: str = Field(..., description="API key for Seren gateway")
 
     default_chairman: str = "claude-opus-4-5"
     min_responses_required: int = 3
@@ -50,15 +45,15 @@ class Settings(BaseSettings):
         members = [
             CouncilMember(
                 "claude",
-                self.claude_publisher_id,
+                "anthropic-claude-api",
                 "claude-sonnet-4-5",
-                endpoint_path="/messages",
+                endpoint_path="/v1/messages",
                 api_format="anthropic",
             ),
-            CouncilMember("gpt5", self.openai_publisher_id, "gpt-5.2"),
-            CouncilMember("kimi", self.moonshot_publisher_id, "kimi-k2-0711-preview"),
-            CouncilMember("gemini", self.gemini_publisher_id, "google/gemini-3-pro-preview"),
-            CouncilMember("sonar", self.perplexity_publisher_id, "sonar"),
+            CouncilMember("gpt5", "openai", "gpt-5.2", endpoint_path="/v1/chat/completions"),
+            CouncilMember("kimi", "moonshot-ai", "kimi-k2-0711-preview", endpoint_path="/v1/chat/completions"),
+            CouncilMember("gemini", "google-gemini-3", "google/gemini-3-pro-preview", endpoint_path="/v1/chat/completions"),
+            CouncilMember("sonar", "perplexity", "sonar", endpoint_path="/chat/completions"),
         ]
         self._validate_member_models(members)
         return members
@@ -81,28 +76,27 @@ class Settings(BaseSettings):
     def get_chairman_config(self, chairman_override: Optional[str] = None) -> CouncilMember:
         model_name = chairman_override or self.default_chairman
 
-        # Route to correct publisher based on model name
         if model_name.startswith("claude"):
             return CouncilMember(
                 "chairman",
-                self.claude_publisher_id,
+                "anthropic-claude-api",
                 model_name,
-                endpoint_path="/messages",
+                endpoint_path="/v1/messages",
                 api_format="anthropic",
             )
         elif model_name.startswith("gpt"):
             return CouncilMember(
                 "chairman",
-                self.openai_publisher_id,
+                "openai",
                 model_name,
+                endpoint_path="/v1/chat/completions",
             )
         else:
-            # Default to Claude for unknown models
             return CouncilMember(
                 "chairman",
-                self.claude_publisher_id,
+                "anthropic-claude-api",
                 model_name,
-                endpoint_path="/messages",
+                endpoint_path="/v1/messages",
                 api_format="anthropic",
             )
 

--- a/backend/council.py
+++ b/backend/council.py
@@ -77,8 +77,8 @@ def _parse_stage2_output(content: str) -> tuple[str, list[str]]:
 class CouncilService:
     """Coordinates the three-stage council deliberation."""
 
-    def __init__(self, caller_wallet: str, client: Optional[X402Client] = None) -> None:
-        self.client = client or X402Client(caller_wallet)
+    def __init__(self, client: Optional[X402Client] = None) -> None:
+        self.client = client or X402Client()
         self.settings = settings
 
     async def stage1_opinions(self, query: str) -> List[LLMResponse]:
@@ -189,8 +189,3 @@ class CouncilService:
             stage2_critiques=stage2_payload,
             metadata=metadata,
         )
-
-
-async def run_council(query: str, chairman: Optional[str] = None) -> CouncilResponse:
-    service = CouncilService()
-    return await service.run_council(query, chairman=chairman)

--- a/backend/main.py
+++ b/backend/main.py
@@ -20,7 +20,7 @@ async def query_council(
     payload: CouncilQuery,
     x_agent_wallet: str = Header(..., alias="X-AGENT-WALLET"),
 ) -> CouncilResponse:
-    service = CouncilService(caller_wallet=x_agent_wallet)
+    service = CouncilService()
     try:
         return await service.run_council(payload.query, chairman=payload.chairman)
     except PaymentRequiredError as exc:

--- a/backend/x402_client.py
+++ b/backend/x402_client.py
@@ -1,4 +1,4 @@
-"""ABOUTME: Async client for querying LLM publishers via x402.
+"""ABOUTME: Async client for querying LLM publishers via Seren gateway.
 ABOUTME: Handles retries, payment errors, and parallel fan-out."""
 
 from __future__ import annotations
@@ -33,11 +33,11 @@ class PaymentRequiredError(X402ClientError):
 
 
 class X402Client:
-    """Async helper that communicates with Seren's x402 gateway."""
+    """Async helper that communicates with Seren's gateway."""
 
-    def __init__(self, caller_wallet: str) -> None:
+    def __init__(self) -> None:
         self.gateway_url = settings.x402_gateway_url
-        self.caller_wallet = caller_wallet
+        self.api_key = settings.seren_api_key
         self.timeout = settings.request_timeout_seconds
         self.retry_attempts = settings.retry_attempts
         self._client: Optional[httpx.AsyncClient] = None
@@ -45,11 +45,11 @@ class X402Client:
     def _get_headers(self) -> dict[str, str]:
         return {
             "Content-Type": "application/json",
-            "X-Payment-Delegation": "true",
+            "Authorization": f"Bearer {self.api_key}",
         }
 
-    def _get_proxy_url(self) -> str:
-        return f"{self.gateway_url}/api/proxy"
+    def _get_model_url(self, member: CouncilMember) -> str:
+        return f"{self.gateway_url}/publishers/{member.slug}{member.endpoint_path}"
 
     async def _get_client(self) -> httpx.AsyncClient:
         if self._client is None:
@@ -90,38 +90,20 @@ class X402Client:
         else:
             return body["choices"][0]["message"]["content"]
 
-    def _build_gateway_request(
-        self,
-        member: CouncilMember,
-        prompt: str,
-        system_prompt: Optional[str] = None,
-    ) -> dict:
-        """Build the x402 gateway proxy request envelope."""
-        llm_payload = self._build_payload(member, prompt, system_prompt)
-        return {
-            "publisherId": member.publisher_id,
-            "agentWallet": self.caller_wallet,
-            "request": {
-                "method": "POST",
-                "path": member.endpoint_path,
-                "body": llm_payload,
-            },
-        }
-
     async def query_model(
         self,
         member: CouncilMember,
         prompt: str,
         system_prompt: Optional[str] = None,
     ) -> LLMResponse:
-        gateway_request = self._build_gateway_request(member, prompt, system_prompt)
-        url = self._get_proxy_url()
+        payload = self._build_payload(member, prompt, system_prompt)
+        url = self._get_model_url(member)
 
         last_error: Optional[str] = None
         for attempt in range(self.retry_attempts + 1):
             try:
                 client = await self._get_client()
-                response = await client.post(url, headers=self._get_headers(), json=gateway_request)
+                response = await client.post(url, headers=self._get_headers(), json=payload)
 
                 if response.status_code == 402:
                     raise PaymentRequiredError(f"Insufficient balance for {member.name}")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -7,12 +7,8 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from fastapi.testclient import TestClient
 
-os.environ.setdefault("X402_GATEWAY_URL", "https://x402.serendb.com")
-os.environ.setdefault("CLAUDE_PUBLISHER_ID", "claude-id")
-os.environ.setdefault("OPENAI_PUBLISHER_ID", "openai-id")
-os.environ.setdefault("MOONSHOT_PUBLISHER_ID", "moonshot-id")
-os.environ.setdefault("GEMINI_PUBLISHER_ID", "gemini-id")
-os.environ.setdefault("PERPLEXITY_PUBLISHER_ID", "perplexity-id")
+os.environ.setdefault("X402_GATEWAY_URL", "https://api.serendb.com")
+os.environ.setdefault("SEREN_API_KEY", "test-api-key")
 
 from backend import models
 from backend.main import app
@@ -59,7 +55,7 @@ def test_query_endpoint_returns_response():
 
     assert response.status_code == 200
     assert response.json()["final_answer"] == "Final"
-    mock_cls.assert_called_once_with(caller_wallet="0xtest")
+    mock_cls.assert_called_once_with()
 
 
 def test_query_endpoint_handles_payment_error():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -12,11 +12,7 @@ import pytest
 def base_env() -> dict:
     return {
         "X402_GATEWAY_URL": "https://test.example.com",
-        "CLAUDE_PUBLISHER_ID": "claude-id",
-        "OPENAI_PUBLISHER_ID": "openai-id",
-        "MOONSHOT_PUBLISHER_ID": "moonshot-id",
-        "GEMINI_PUBLISHER_ID": "gemini-id",
-        "PERPLEXITY_PUBLISHER_ID": "perplexity-id",
+        "SEREN_API_KEY": "test-api-key",
     }
 
 
@@ -49,3 +45,31 @@ def test_get_chairman_respects_override(base_env):
     chairman = config_module.settings.get_chairman_config("gpt-5")
     assert chairman.model == "gpt-5"
     assert chairman.name == "chairman"
+
+
+def test_council_members_have_correct_slugs(base_env):
+    config_module = _load_config(base_env)
+
+    members = config_module.settings.get_council_members()
+    slugs = {m.name: m.slug for m in members}
+    assert slugs == {
+        "claude": "anthropic-claude-api",
+        "gpt5": "openai",
+        "kimi": "moonshot-ai",
+        "gemini": "google-gemini-3",
+        "sonar": "perplexity",
+    }
+
+
+def test_council_members_have_correct_endpoint_paths(base_env):
+    config_module = _load_config(base_env)
+
+    members = config_module.settings.get_council_members()
+    paths = {m.name: m.endpoint_path for m in members}
+    assert paths == {
+        "claude": "/v1/messages",
+        "gpt5": "/v1/chat/completions",
+        "kimi": "/v1/chat/completions",
+        "gemini": "/v1/chat/completions",
+        "sonar": "/chat/completions",
+    }

--- a/tests/test_council.py
+++ b/tests/test_council.py
@@ -81,12 +81,8 @@ class FakeClient:
 @pytest.fixture()
 def env_values() -> dict:
     return {
-        "X402_GATEWAY_URL": "https://x402.serendb.com",
-        "CLAUDE_PUBLISHER_ID": "claude-id",
-        "OPENAI_PUBLISHER_ID": "openai-id",
-        "MOONSHOT_PUBLISHER_ID": "moonshot-id",
-        "GEMINI_PUBLISHER_ID": "gemini-id",
-        "PERPLEXITY_PUBLISHER_ID": "perplexity-id",
+        "X402_GATEWAY_URL": "https://api.serendb.com",
+        "SEREN_API_KEY": "test-api-key",
         "MIN_RESPONSES_REQUIRED": "3",
     }
 
@@ -95,7 +91,6 @@ def env_values() -> dict:
 async def test_stage1_opinions_returns_five(env_values):
     config_module, _, client_module, council_module = _load_council_modules(env_values)
     service = council_module.CouncilService(
-        caller_wallet="0xtest",
         client=FakeClient(client_module.LLMResponse),
     )
 
@@ -109,7 +104,6 @@ async def test_stage1_opinions_returns_five(env_values):
 async def test_run_council_builds_response(env_values):
     config_module, models_module, client_module, council_module = _load_council_modules(env_values)
     service = council_module.CouncilService(
-        caller_wallet="0xtest",
         client=FakeClient(client_module.LLMResponse),
     )
 
@@ -133,7 +127,6 @@ async def test_run_council_fails_when_not_enough_responses(env_values):
     _, _, client_module, council_module = _load_council_modules(env_values)
     failing = {"claude", "gpt5", "kimi"}
     service = council_module.CouncilService(
-        caller_wallet="0xtest",
         client=FakeClient(client_module.LLMResponse, failing_members=failing),
     )
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -8,20 +8,15 @@ from unittest.mock import patch
 import pytest
 from fastapi.testclient import TestClient
 
-os.environ.setdefault("X402_GATEWAY_URL", "https://x402.serendb.com")
-os.environ.setdefault("CLAUDE_PUBLISHER_ID", "claude-id")
-os.environ.setdefault("OPENAI_PUBLISHER_ID", "openai-id")
-os.environ.setdefault("MOONSHOT_PUBLISHER_ID", "moonshot-id")
-os.environ.setdefault("GEMINI_PUBLISHER_ID", "gemini-id")
-os.environ.setdefault("PERPLEXITY_PUBLISHER_ID", "perplexity-id")
+os.environ.setdefault("X402_GATEWAY_URL", "https://api.serendb.com")
+os.environ.setdefault("SEREN_API_KEY", "test-api-key")
 
 from backend.main import app
 from backend.x402_client import LLMResponse
 
 
 class FakeX402Client:
-    def __init__(self, caller_wallet: str):
-        self.caller_wallet = caller_wallet
+    def __init__(self):
         self.stage1_counter = 0
 
     async def query_models_parallel(self, members, prompt, system_prompt=None):

--- a/tests/test_x402_client.py
+++ b/tests/test_x402_client.py
@@ -23,12 +23,8 @@ def _load_modules(env: dict) -> tuple[ModuleType, ModuleType]:
 @pytest.fixture()
 def env_values() -> dict:
     return {
-        "X402_GATEWAY_URL": "https://x402.serendb.com",
-        "CLAUDE_PUBLISHER_ID": "claude-id",
-        "OPENAI_PUBLISHER_ID": "openai-id",
-        "MOONSHOT_PUBLISHER_ID": "moonshot-id",
-        "GEMINI_PUBLISHER_ID": "gemini-id",
-        "PERPLEXITY_PUBLISHER_ID": "perplexity-id",
+        "X402_GATEWAY_URL": "https://api.serendb.com",
+        "SEREN_API_KEY": "test-api-key",
         "RETRY_ATTEMPTS": "1",
     }
 
@@ -36,10 +32,12 @@ def env_values() -> dict:
 @pytest.mark.asyncio()
 async def test_query_model_success(env_values, respx_mock):
     config_module, client_module = _load_modules(env_values)
-    client = client_module.X402Client(caller_wallet="0xtest")
-    member = config_module.settings.get_council_members()[0]  # Claude with /messages
+    client = client_module.X402Client()
+    member = config_module.settings.get_council_members()[0]  # Claude
 
-    route = respx_mock.post("https://x402.serendb.com/api/proxy").mock(
+    route = respx_mock.post(
+        "https://api.serendb.com/publishers/anthropic-claude-api/v1/messages"
+    ).mock(
         return_value=Response(200, json={"content": [{"text": "Hello from Claude"}]})
     )
 
@@ -49,18 +47,22 @@ async def test_query_model_success(env_values, respx_mock):
     assert result.success is True
     assert result.content == "Hello from Claude"
 
+    request = route.calls[0].request
+    assert request.headers["authorization"] == "Bearer test-api-key"
+    assert "x-payment-delegation" not in request.headers
+
 
 @pytest.mark.asyncio()
 async def test_query_model_payment_error(env_values, respx_mock):
     _, client_module = _load_modules(env_values)
-    client = client_module.X402Client(caller_wallet="0xtest")
+    client = client_module.X402Client()
     member = client_module.CouncilMember(
-        "test", "test-id", "test-model", "/chat/completions", "openai"
+        "test", "test-publisher", "test-model", "/v1/chat/completions", "openai"
     )
 
-    respx_mock.post("https://x402.serendb.com/api/proxy").mock(
-        return_value=Response(402)
-    )
+    respx_mock.post(
+        "https://api.serendb.com/publishers/test-publisher/v1/chat/completions"
+    ).mock(return_value=Response(402))
 
     with pytest.raises(client_module.PaymentRequiredError):
         await client.query_model(member, "Hello?")
@@ -69,14 +71,19 @@ async def test_query_model_payment_error(env_values, respx_mock):
 @pytest.mark.asyncio()
 async def test_query_models_parallel_collects_results(env_values, respx_mock):
     config_module, client_module = _load_modules(env_values)
-    client = client_module.X402Client(caller_wallet="0xtest")
+    client = client_module.X402Client()
     members = config_module.settings.get_council_members()[:2]  # Claude and GPT5
 
-    responses = [
-        Response(200, json={"content": [{"text": "Reply from claude"}]}),
-        Response(200, json={"choices": [{"message": {"content": "Reply from gpt5"}}]}),
-    ]
-    respx_mock.post("https://x402.serendb.com/api/proxy").mock(side_effect=responses)
+    respx_mock.post(
+        "https://api.serendb.com/publishers/anthropic-claude-api/v1/messages"
+    ).mock(
+        return_value=Response(200, json={"content": [{"text": "Reply from claude"}]})
+    )
+    respx_mock.post(
+        "https://api.serendb.com/publishers/openai/v1/chat/completions"
+    ).mock(
+        return_value=Response(200, json={"choices": [{"message": {"content": "Reply from gpt5"}}]})
+    )
 
     results = await client.query_models_parallel(members, "Discuss")
 


### PR DESCRIPTION
## Summary

- Migrates x402 client from expired `x402.serendb.com` gateway to `api.serendb.com`
- Replaces `POST /api/proxy` envelope pattern with direct `POST /publishers/{slug}/{path}` routing
- Switches auth from `X-Payment-Delegation` header to `Authorization: Bearer` token
- Hardcodes publisher slugs, removes 5 `*_PUBLISHER_ID` env vars, adds `SEREN_API_KEY`
- Removes `caller_wallet` threading (gateway authenticates via API key now)

## Test plan

- [x] All 19 tests pass locally
- [ ] Set `SEREN_API_KEY` and `X402_GATEWAY_URL=https://api.serendb.com` in Vercel env vars
- [ ] Deploy to Vercel
- [ ] Verify `POST /v1/council/query` returns 200 with council response

Closes serenorg/seren-desktop#1527

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com